### PR TITLE
Optimize by decreasing `br_mis_pred`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ make benchmark
 ### ARM Cortex-A72
 
 ```bash
-022-05-11T16:31:36+05:30
+2022-05-12T20:24:55+05:30
 Running ./bench/a.out
 Run on (4 X 1800 MHz CPU s)
-Load Average: 0.74, 1.20, 1.45
+Load Average: 3.25, 0.98, 0.57
 ------------------------------------------------------------------------------
 Benchmark                    Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------
-harpocrates_encrypt       3443 ns         3443 ns       203330 bytes_per_second=4.43226M/s
-harpocrates_decrypt       3461 ns         3461 ns       202333 bytes_per_second=4.40924M/s
+harpocrates_encrypt       2349 ns         2349 ns       296555 bytes_per_second=6.49583M/s
+harpocrates_decrypt       2317 ns         2317 ns       302110 bytes_per_second=6.58582M/s
 ```
 
 ## Usage

--- a/include/harpocrates_utils.hpp
+++ b/include/harpocrates_utils.hpp
@@ -170,38 +170,280 @@ static inline void
 column_substitution(uint16_t* const __restrict state,
                     const uint8_t* const __restrict lut)
 {
-  for (size_t i = 0; i < harpocrates_common::N_COLS; i++) {
-    const uint8_t b0 = static_cast<uint8_t>((state[0] >> (15ul - i)) & 0b1u);
-    const uint8_t b1 = static_cast<uint8_t>((state[1] >> (15ul - i)) & 0b1u);
-    const uint8_t b2 = static_cast<uint8_t>((state[2] >> (15ul - i)) & 0b1u);
-    const uint8_t b3 = static_cast<uint8_t>((state[3] >> (15ul - i)) & 0b1u);
-    const uint8_t b4 = static_cast<uint8_t>((state[4] >> (15ul - i)) & 0b1u);
-    const uint8_t b5 = static_cast<uint8_t>((state[5] >> (15ul - i)) & 0b1u);
-    const uint8_t b6 = static_cast<uint8_t>((state[6] >> (15ul - i)) & 0b1u);
-    const uint8_t b7 = static_cast<uint8_t>((state[7] >> (15ul - i)) & 0b1u);
+  const uint8_t row0_hi = static_cast<uint8_t>(state[0] >> 8);
+  const uint8_t row1_hi = static_cast<uint8_t>(state[1] >> 8);
+  const uint8_t row2_hi = static_cast<uint8_t>(state[2] >> 8);
+  const uint8_t row3_hi = static_cast<uint8_t>(state[3] >> 8);
+  const uint8_t row4_hi = static_cast<uint8_t>(state[4] >> 8);
+  const uint8_t row5_hi = static_cast<uint8_t>(state[5] >> 8);
+  const uint8_t row6_hi = static_cast<uint8_t>(state[6] >> 8);
+  const uint8_t row7_hi = static_cast<uint8_t>(state[7] >> 8);
 
-    const uint8_t col0 = (b0 << 7) | (b1 << 6) | (b2 << 5) | (b3 << 4) |
-                         (b4 << 3) | (b5 << 2) | (b6 << 1) | (b7 << 0);
+  const uint8_t col0 =
+    ((row0_hi & 0b10000000) >> 0) | ((row1_hi & 0b10000000) >> 1) |
+    ((row2_hi & 0b10000000) >> 2) | ((row3_hi & 0b10000000) >> 3) |
+    ((row4_hi & 0b10000000) >> 4) | ((row5_hi & 0b10000000) >> 5) |
+    ((row6_hi & 0b10000000) >> 6) | ((row7_hi & 0b10000000) >> 7);
+  const uint8_t scol0 = lut[col0];
 
-    const uint8_t col1 = lut[col0];
+  const uint8_t col1 =
+    ((row0_hi & 0b01000000) << 1) | ((row1_hi & 0b01000000) >> 0) |
+    ((row2_hi & 0b01000000) >> 1) | ((row3_hi & 0b01000000) >> 2) |
+    ((row4_hi & 0b01000000) >> 3) | ((row5_hi & 0b01000000) >> 4) |
+    ((row6_hi & 0b01000000) >> 5) | ((row7_hi & 0b01000000) >> 6);
+  const uint8_t scol1 = lut[col1];
 
-    state[0] = (state[0] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 7) & 0b1u) << (15ul - i));
-    state[1] = (state[1] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 6) & 0b1u) << (15ul - i));
-    state[2] = (state[2] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 5) & 0b1u) << (15ul - i));
-    state[3] = (state[3] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 4) & 0b1u) << (15ul - i));
-    state[4] = (state[4] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 3) & 0b1u) << (15ul - i));
-    state[5] = (state[5] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 2) & 0b1u) << (15ul - i));
-    state[6] = (state[6] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 1) & 0b1u) << (15ul - i));
-    state[7] = (state[7] & harpocrates_common::COL_MASKS[i]) |
-               (static_cast<uint16_t>((col1 >> 0) & 0b1u) << (15ul - i));
-  }
+  const uint8_t col2 =
+    ((row0_hi & 0b00100000) << 2) | ((row1_hi & 0b00100000) << 1) |
+    ((row2_hi & 0b00100000) >> 0) | ((row3_hi & 0b00100000) >> 1) |
+    ((row4_hi & 0b00100000) >> 2) | ((row5_hi & 0b00100000) >> 3) |
+    ((row6_hi & 0b00100000) >> 4) | ((row7_hi & 0b00100000) >> 5);
+  const uint8_t scol2 = lut[col2];
+
+  const uint8_t col3 =
+    ((row0_hi & 0b00010000) << 3) | ((row1_hi & 0b00010000) << 2) |
+    ((row2_hi & 0b00010000) << 1) | ((row3_hi & 0b00010000) >> 0) |
+    ((row4_hi & 0b00010000) >> 1) | ((row5_hi & 0b00010000) >> 2) |
+    ((row6_hi & 0b00010000) >> 3) | ((row7_hi & 0b00010000) >> 4);
+  const uint8_t scol3 = lut[col3];
+
+  const uint8_t col4 =
+    ((row0_hi & 0b00001000) << 4) | ((row1_hi & 0b00001000) << 3) |
+    ((row2_hi & 0b00001000) << 2) | ((row3_hi & 0b00001000) << 1) |
+    ((row4_hi & 0b00001000) >> 0) | ((row5_hi & 0b00001000) >> 1) |
+    ((row6_hi & 0b00001000) >> 2) | ((row7_hi & 0b00001000) >> 3);
+  const uint8_t scol4 = lut[col4];
+
+  const uint8_t col5 =
+    ((row0_hi & 0b00000100) << 5) | ((row1_hi & 0b00000100) << 4) |
+    ((row2_hi & 0b00000100) << 3) | ((row3_hi & 0b00000100) << 2) |
+    ((row4_hi & 0b00000100) << 1) | ((row5_hi & 0b00000100) >> 0) |
+    ((row6_hi & 0b00000100) >> 1) | ((row7_hi & 0b00000100) >> 2);
+  const uint8_t scol5 = lut[col5];
+
+  const uint8_t col6 =
+    ((row0_hi & 0b00000010) << 6) | ((row1_hi & 0b00000010) << 5) |
+    ((row2_hi & 0b00000010) << 4) | ((row3_hi & 0b00000010) << 3) |
+    ((row4_hi & 0b00000010) << 2) | ((row5_hi & 0b00000010) << 1) |
+    ((row6_hi & 0b00000010) >> 0) | ((row7_hi & 0b00000010) >> 1);
+  const uint8_t scol6 = lut[col6];
+
+  const uint8_t col7 =
+    ((row0_hi & 0b00000001) << 7) | ((row1_hi & 0b00000001) << 6) |
+    ((row2_hi & 0b00000001) << 5) | ((row3_hi & 0b00000001) << 4) |
+    ((row4_hi & 0b00000001) << 3) | ((row5_hi & 0b00000001) << 2) |
+    ((row6_hi & 0b00000001) << 1) | ((row7_hi & 0b00000001) << 0);
+  const uint8_t scol7 = lut[col7];
+
+  const uint8_t row0_lo = static_cast<uint8_t>(state[0]);
+  const uint8_t row1_lo = static_cast<uint8_t>(state[1]);
+  const uint8_t row2_lo = static_cast<uint8_t>(state[2]);
+  const uint8_t row3_lo = static_cast<uint8_t>(state[3]);
+  const uint8_t row4_lo = static_cast<uint8_t>(state[4]);
+  const uint8_t row5_lo = static_cast<uint8_t>(state[5]);
+  const uint8_t row6_lo = static_cast<uint8_t>(state[6]);
+  const uint8_t row7_lo = static_cast<uint8_t>(state[7]);
+
+  const uint8_t col8 =
+    ((row0_lo & 0b10000000) >> 0) | ((row1_lo & 0b10000000) >> 1) |
+    ((row2_lo & 0b10000000) >> 2) | ((row3_lo & 0b10000000) >> 3) |
+    ((row4_lo & 0b10000000) >> 4) | ((row5_lo & 0b10000000) >> 5) |
+    ((row6_lo & 0b10000000) >> 6) | ((row7_lo & 0b10000000) >> 7);
+  const uint8_t scol8 = lut[col8];
+
+  const uint8_t col9 =
+    ((row0_lo & 0b01000000) << 1) | ((row1_lo & 0b01000000) >> 0) |
+    ((row2_lo & 0b01000000) >> 1) | ((row3_lo & 0b01000000) >> 2) |
+    ((row4_lo & 0b01000000) >> 3) | ((row5_lo & 0b01000000) >> 4) |
+    ((row6_lo & 0b01000000) >> 5) | ((row7_lo & 0b01000000) >> 6);
+  const uint8_t scol9 = lut[col9];
+
+  const uint8_t col10 =
+    ((row0_lo & 0b00100000) << 2) | ((row1_lo & 0b00100000) << 1) |
+    ((row2_lo & 0b00100000) >> 0) | ((row3_lo & 0b00100000) >> 1) |
+    ((row4_lo & 0b00100000) >> 2) | ((row5_lo & 0b00100000) >> 3) |
+    ((row6_lo & 0b00100000) >> 4) | ((row7_lo & 0b00100000) >> 5);
+  const uint8_t scol10 = lut[col10];
+
+  const uint8_t col11 =
+    ((row0_lo & 0b00010000) << 3) | ((row1_lo & 0b00010000) << 2) |
+    ((row2_lo & 0b00010000) << 1) | ((row3_lo & 0b00010000) >> 0) |
+    ((row4_lo & 0b00010000) >> 1) | ((row5_lo & 0b00010000) >> 2) |
+    ((row6_lo & 0b00010000) >> 3) | ((row7_lo & 0b00010000) >> 4);
+  const uint8_t scol11 = lut[col11];
+
+  const uint8_t col12 =
+    ((row0_lo & 0b00001000) << 4) | ((row1_lo & 0b00001000) << 3) |
+    ((row2_lo & 0b00001000) << 2) | ((row3_lo & 0b00001000) << 1) |
+    ((row4_lo & 0b00001000) >> 0) | ((row5_lo & 0b00001000) >> 1) |
+    ((row6_lo & 0b00001000) >> 2) | ((row7_lo & 0b00001000) >> 3);
+  const uint8_t scol12 = lut[col12];
+
+  const uint8_t col13 =
+    ((row0_lo & 0b00000100) << 5) | ((row1_lo & 0b00000100) << 4) |
+    ((row2_lo & 0b00000100) << 3) | ((row3_lo & 0b00000100) << 2) |
+    ((row4_lo & 0b00000100) << 1) | ((row5_lo & 0b00000100) >> 0) |
+    ((row6_lo & 0b00000100) >> 1) | ((row7_lo & 0b00000100) >> 2);
+  const uint8_t scol13 = lut[col13];
+
+  const uint8_t col14 =
+    ((row0_lo & 0b00000010) << 6) | ((row1_lo & 0b00000010) << 5) |
+    ((row2_lo & 0b00000010) << 4) | ((row3_lo & 0b00000010) << 3) |
+    ((row4_lo & 0b00000010) << 2) | ((row5_lo & 0b00000010) << 1) |
+    ((row6_lo & 0b00000010) >> 0) | ((row7_lo & 0b00000010) >> 1);
+  const uint8_t scol14 = lut[col14];
+
+  const uint8_t col15 =
+    ((row0_lo & 0b00000001) << 7) | ((row1_lo & 0b00000001) << 6) |
+    ((row2_lo & 0b00000001) << 5) | ((row3_lo & 0b00000001) << 4) |
+    ((row4_lo & 0b00000001) << 3) | ((row5_lo & 0b00000001) << 2) |
+    ((row6_lo & 0b00000001) << 1) | ((row7_lo & 0b00000001) << 0);
+  const uint8_t scol15 = lut[col15];
+
+  const uint16_t row0 = (static_cast<uint16_t>(scol0 & 0b10000000) << 8) |
+                        (static_cast<uint16_t>(scol1 & 0b10000000) << 7) |
+                        (static_cast<uint16_t>(scol2 & 0b10000000) << 6) |
+                        (static_cast<uint16_t>(scol3 & 0b10000000) << 5) |
+                        (static_cast<uint16_t>(scol4 & 0b10000000) << 4) |
+                        (static_cast<uint16_t>(scol5 & 0b10000000) << 3) |
+                        (static_cast<uint16_t>(scol6 & 0b10000000) << 2) |
+                        (static_cast<uint16_t>(scol7 & 0b10000000) << 1) |
+                        (static_cast<uint16_t>(scol8 & 0b10000000) >> 0) |
+                        (static_cast<uint16_t>(scol9 & 0b10000000) >> 1) |
+                        (static_cast<uint16_t>(scol10 & 0b10000000) >> 2) |
+                        (static_cast<uint16_t>(scol11 & 0b10000000) >> 3) |
+                        (static_cast<uint16_t>(scol12 & 0b10000000) >> 4) |
+                        (static_cast<uint16_t>(scol13 & 0b10000000) >> 5) |
+                        (static_cast<uint16_t>(scol14 & 0b10000000) >> 6) |
+                        (static_cast<uint16_t>(scol15 & 0b10000000) >> 7);
+
+  const uint16_t row1 = (static_cast<uint16_t>(scol0 & 0b01000000) << 9) |
+                        (static_cast<uint16_t>(scol1 & 0b01000000) << 8) |
+                        (static_cast<uint16_t>(scol2 & 0b01000000) << 7) |
+                        (static_cast<uint16_t>(scol3 & 0b01000000) << 6) |
+                        (static_cast<uint16_t>(scol4 & 0b01000000) << 5) |
+                        (static_cast<uint16_t>(scol5 & 0b01000000) << 4) |
+                        (static_cast<uint16_t>(scol6 & 0b01000000) << 3) |
+                        (static_cast<uint16_t>(scol7 & 0b01000000) << 2) |
+                        (static_cast<uint16_t>(scol8 & 0b01000000) << 1) |
+                        (static_cast<uint16_t>(scol9 & 0b01000000) >> 0) |
+                        (static_cast<uint16_t>(scol10 & 0b01000000) >> 1) |
+                        (static_cast<uint16_t>(scol11 & 0b01000000) >> 2) |
+                        (static_cast<uint16_t>(scol12 & 0b01000000) >> 3) |
+                        (static_cast<uint16_t>(scol13 & 0b01000000) >> 4) |
+                        (static_cast<uint16_t>(scol14 & 0b01000000) >> 5) |
+                        (static_cast<uint16_t>(scol15 & 0b01000000) >> 6);
+
+  const uint16_t row2 = (static_cast<uint16_t>(scol0 & 0b00100000) << 10) |
+                        (static_cast<uint16_t>(scol1 & 0b00100000) << 9) |
+                        (static_cast<uint16_t>(scol2 & 0b00100000) << 8) |
+                        (static_cast<uint16_t>(scol3 & 0b00100000) << 7) |
+                        (static_cast<uint16_t>(scol4 & 0b00100000) << 6) |
+                        (static_cast<uint16_t>(scol5 & 0b00100000) << 5) |
+                        (static_cast<uint16_t>(scol6 & 0b00100000) << 4) |
+                        (static_cast<uint16_t>(scol7 & 0b00100000) << 3) |
+                        (static_cast<uint16_t>(scol8 & 0b00100000) << 2) |
+                        (static_cast<uint16_t>(scol9 & 0b00100000) << 1) |
+                        (static_cast<uint16_t>(scol10 & 0b00100000) >> 0) |
+                        (static_cast<uint16_t>(scol11 & 0b00100000) >> 1) |
+                        (static_cast<uint16_t>(scol12 & 0b00100000) >> 2) |
+                        (static_cast<uint16_t>(scol13 & 0b00100000) >> 3) |
+                        (static_cast<uint16_t>(scol14 & 0b00100000) >> 4) |
+                        (static_cast<uint16_t>(scol15 & 0b00100000) >> 5);
+
+  const uint16_t row3 = (static_cast<uint16_t>(scol0 & 0b00010000) << 11) |
+                        (static_cast<uint16_t>(scol1 & 0b00010000) << 10) |
+                        (static_cast<uint16_t>(scol2 & 0b00010000) << 9) |
+                        (static_cast<uint16_t>(scol3 & 0b00010000) << 8) |
+                        (static_cast<uint16_t>(scol4 & 0b00010000) << 7) |
+                        (static_cast<uint16_t>(scol5 & 0b00010000) << 6) |
+                        (static_cast<uint16_t>(scol6 & 0b00010000) << 5) |
+                        (static_cast<uint16_t>(scol7 & 0b00010000) << 4) |
+                        (static_cast<uint16_t>(scol8 & 0b00010000) << 3) |
+                        (static_cast<uint16_t>(scol9 & 0b00010000) << 2) |
+                        (static_cast<uint16_t>(scol10 & 0b00010000) << 1) |
+                        (static_cast<uint16_t>(scol11 & 0b00010000) >> 0) |
+                        (static_cast<uint16_t>(scol12 & 0b00010000) >> 1) |
+                        (static_cast<uint16_t>(scol13 & 0b00010000) >> 2) |
+                        (static_cast<uint16_t>(scol14 & 0b00010000) >> 3) |
+                        (static_cast<uint16_t>(scol15 & 0b00010000) >> 4);
+
+  const uint16_t row4 = (static_cast<uint16_t>(scol0 & 0b00001000) << 12) |
+                        (static_cast<uint16_t>(scol1 & 0b00001000) << 11) |
+                        (static_cast<uint16_t>(scol2 & 0b00001000) << 10) |
+                        (static_cast<uint16_t>(scol3 & 0b00001000) << 9) |
+                        (static_cast<uint16_t>(scol4 & 0b00001000) << 8) |
+                        (static_cast<uint16_t>(scol5 & 0b00001000) << 7) |
+                        (static_cast<uint16_t>(scol6 & 0b00001000) << 6) |
+                        (static_cast<uint16_t>(scol7 & 0b00001000) << 5) |
+                        (static_cast<uint16_t>(scol8 & 0b00001000) << 4) |
+                        (static_cast<uint16_t>(scol9 & 0b00001000) << 3) |
+                        (static_cast<uint16_t>(scol10 & 0b00001000) << 2) |
+                        (static_cast<uint16_t>(scol11 & 0b00001000) << 1) |
+                        (static_cast<uint16_t>(scol12 & 0b00001000) >> 0) |
+                        (static_cast<uint16_t>(scol13 & 0b00001000) >> 1) |
+                        (static_cast<uint16_t>(scol14 & 0b00001000) >> 2) |
+                        (static_cast<uint16_t>(scol15 & 0b00001000) >> 3);
+
+  const uint16_t row5 = (static_cast<uint16_t>(scol0 & 0b00000100) << 13) |
+                        (static_cast<uint16_t>(scol1 & 0b00000100) << 12) |
+                        (static_cast<uint16_t>(scol2 & 0b00000100) << 11) |
+                        (static_cast<uint16_t>(scol3 & 0b00000100) << 10) |
+                        (static_cast<uint16_t>(scol4 & 0b00000100) << 9) |
+                        (static_cast<uint16_t>(scol5 & 0b00000100) << 8) |
+                        (static_cast<uint16_t>(scol6 & 0b00000100) << 7) |
+                        (static_cast<uint16_t>(scol7 & 0b00000100) << 6) |
+                        (static_cast<uint16_t>(scol8 & 0b00000100) << 5) |
+                        (static_cast<uint16_t>(scol9 & 0b00000100) << 4) |
+                        (static_cast<uint16_t>(scol10 & 0b00000100) << 3) |
+                        (static_cast<uint16_t>(scol11 & 0b00000100) << 2) |
+                        (static_cast<uint16_t>(scol12 & 0b00000100) << 1) |
+                        (static_cast<uint16_t>(scol13 & 0b00000100) >> 0) |
+                        (static_cast<uint16_t>(scol14 & 0b00000100) >> 1) |
+                        (static_cast<uint16_t>(scol15 & 0b00000100) >> 2);
+
+  const uint16_t row6 = (static_cast<uint16_t>(scol0 & 0b00000010) << 14) |
+                        (static_cast<uint16_t>(scol1 & 0b00000010) << 13) |
+                        (static_cast<uint16_t>(scol2 & 0b00000010) << 12) |
+                        (static_cast<uint16_t>(scol3 & 0b00000010) << 11) |
+                        (static_cast<uint16_t>(scol4 & 0b00000010) << 10) |
+                        (static_cast<uint16_t>(scol5 & 0b00000010) << 9) |
+                        (static_cast<uint16_t>(scol6 & 0b00000010) << 8) |
+                        (static_cast<uint16_t>(scol7 & 0b00000010) << 7) |
+                        (static_cast<uint16_t>(scol8 & 0b00000010) << 6) |
+                        (static_cast<uint16_t>(scol9 & 0b00000010) << 5) |
+                        (static_cast<uint16_t>(scol10 & 0b00000010) << 4) |
+                        (static_cast<uint16_t>(scol11 & 0b00000010) << 3) |
+                        (static_cast<uint16_t>(scol12 & 0b00000010) << 2) |
+                        (static_cast<uint16_t>(scol13 & 0b00000010) << 1) |
+                        (static_cast<uint16_t>(scol14 & 0b00000010) >> 0) |
+                        (static_cast<uint16_t>(scol15 & 0b00000010) >> 1);
+
+  const uint16_t row7 = (static_cast<uint16_t>(scol0 & 0b00000001) << 15) |
+                        (static_cast<uint16_t>(scol1 & 0b00000001) << 14) |
+                        (static_cast<uint16_t>(scol2 & 0b00000001) << 13) |
+                        (static_cast<uint16_t>(scol3 & 0b00000001) << 12) |
+                        (static_cast<uint16_t>(scol4 & 0b00000001) << 11) |
+                        (static_cast<uint16_t>(scol5 & 0b00000001) << 10) |
+                        (static_cast<uint16_t>(scol6 & 0b00000001) << 9) |
+                        (static_cast<uint16_t>(scol7 & 0b00000001) << 8) |
+                        (static_cast<uint16_t>(scol8 & 0b00000001) << 7) |
+                        (static_cast<uint16_t>(scol9 & 0b00000001) << 6) |
+                        (static_cast<uint16_t>(scol10 & 0b00000001) << 5) |
+                        (static_cast<uint16_t>(scol11 & 0b00000001) << 4) |
+                        (static_cast<uint16_t>(scol12 & 0b00000001) << 3) |
+                        (static_cast<uint16_t>(scol13 & 0b00000001) << 2) |
+                        (static_cast<uint16_t>(scol14 & 0b00000001) << 1) |
+                        (static_cast<uint16_t>(scol15 & 0b00000001) >> 0);
+
+  state[0] = row0;
+  state[1] = row1;
+  state[2] = row2;
+  state[3] = row3;
+  state[4] = row4;
+  state[5] = row5;
+  state[6] = row6;
+  state[7] = row7;
 }
 
 // Right to left convoluted substitution, as described in point (4) of

--- a/include/harpocrates_utils.hpp
+++ b/include/harpocrates_utils.hpp
@@ -119,28 +119,28 @@ left_to_right_convoluted_substitution(uint16_t* const __restrict state,
     // step 1
     const uint8_t t0 = static_cast<uint8_t>(row >> 8);
     const uint8_t t1 = lut[t0];
-    const uint8_t msb0 = t1 >> 6;
+    const uint8_t msb0 = t1 & 0b11000000;
 
     // step 2
     const uint8_t t2 = (t1 << 2) | lo_msb0;
     const uint8_t t3 = lut[t2];
-    const uint8_t msb2 = t3 >> 6;
+    const uint8_t msb2 = (t3 & 0b11000000) >> 2;
 
     // step 3
     const uint8_t t4 = (t3 << 2) | lo_msb2;
     const uint8_t t5 = lut[t4];
-    const uint8_t msb4 = t5 >> 6;
+    const uint8_t msb4 = (t5 & 0b11000000) >> 4;
 
     // step 4
     const uint8_t t6 = (t5 << 2) | lo_msb4;
     const uint8_t t7 = lut[t6];
-    const uint8_t msb6 = t7 >> 6;
+    const uint8_t msb6 = (t7 & 0b11000000) >> 6;
 
     // step 5
     const uint8_t t8 = (t7 << 2) | lo_msb6;
     const uint8_t t9 = lut[t8];
 
-    const uint8_t hi = (msb0 << 6) | (msb2 << 4) | (msb4 << 2) | msb6;
+    const uint8_t hi = msb0 | msb2 | msb4 | msb6;
     state[i] = (static_cast<uint16_t>(hi) << 8) | static_cast<uint16_t>(t9);
   }
 }
@@ -479,23 +479,23 @@ right_to_left_convoluted_substitution(uint16_t* const __restrict state,
     // step 2
     const uint8_t t2 = hi_msb6 | (t1 >> 2);
     const uint8_t t3 = lut[t2];
-    const uint8_t msb4 = t3 & 0b11;
+    const uint8_t msb4 = (t3 & 0b11) << 2;
 
     // step 3
     const uint8_t t4 = hi_msb4 | (t3 >> 2);
     const uint8_t t5 = lut[t4];
-    const uint8_t msb2 = t5 & 0b11;
+    const uint8_t msb2 = (t5 & 0b11) << 4;
 
     // step 4
     const uint8_t t6 = hi_msb2 | (t5 >> 2);
     const uint8_t t7 = lut[t6];
-    const uint8_t msb0 = t7 & 0b11;
+    const uint8_t msb0 = (t7 & 0b11) << 6;
 
     // step 5
     const uint8_t t8 = hi_msb0 | (t7 >> 2);
     const uint8_t t9 = lut[t8];
 
-    const uint8_t lo = (msb0 << 6) | (msb2 << 4) | (msb4 << 2) | msb6;
+    const uint8_t lo = msb0 | msb2 | msb4 | msb6;
     state[i] = (static_cast<uint16_t>(t9) << 8) | static_cast<uint16_t>(lo);
   }
 }

--- a/include/harpocrates_utils.hpp
+++ b/include/harpocrates_utils.hpp
@@ -46,9 +46,21 @@ shuffle(uint8_t* const lut)
 static inline void
 generate_lut(uint8_t* const lut)
 {
-  constexpr size_t n = 256;
+  constexpr size_t n = 64;
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
+#endif
   for (size_t i = 0; i < n; i++) {
-    lut[i] = i;
+    const size_t off = i << 2;
+
+    lut[off] = off;
+    lut[off ^ 1] = off ^ 1;
+    lut[off ^ 2] = off ^ 2;
+    lut[off ^ 3] = off ^ 3;
   }
 
   shuffle(lut);
@@ -61,9 +73,21 @@ static inline void
 generate_inv_lut(const uint8_t* const __restrict lut,
                  uint8_t* const __restrict inv_lut)
 {
-  constexpr size_t n = 256;
+  constexpr size_t n = 64;
+
+#if defined __clang__
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
+#endif
   for (size_t i = 0; i < n; i++) {
-    inv_lut[lut[i]] = i;
+    const size_t off = i << 2;
+
+    inv_lut[lut[off]] = off;
+    inv_lut[lut[off ^ 1]] = off ^ 1;
+    inv_lut[lut[off ^ 2]] = off ^ 2;
+    inv_lut[lut[off ^ 3]] = off ^ 3;
   }
 }
 


### PR DESCRIPTION
- Attempt to reduce # -of places where CPU needs to decide which branch to take
- Enable compiler ( g++, clang++ ) specific pragma(s) for hinting safe loop unroll
- Eventually target increasing throughput of `harpocrates::{encrypt, decrypt}` routines
